### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Code CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/arthurfiorette/try/security/code-scanning/2](https://github.com/arthurfiorette/try/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the minimum required scopes to `GITHUB_TOKEN`. For a simple CI workflow that just checks out code, installs dependencies, runs checks, and uploads coverage to Codecov using its own token, `contents: read` is sufficient. This can be set at the workflow root (applies to all jobs) or at the specific job level.

The best, least intrusive fix here is to add a workflow-level `permissions` block immediately after the `name: Code CI` line in `.github/workflows/ci.yml`, setting `contents: read`. This will restrict `GITHUB_TOKEN` to only read repository contents for the whole workflow, without changing any existing job behavior. No additional imports, methods, or definitions are needed; this is purely a YAML configuration change within the GitHub Actions workflow file.

Specifically, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Code CI`). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
